### PR TITLE
add support to scan Bootlegger QR codes

### DIFF
--- a/lib/features/address_validator/money_badger_validator.dart
+++ b/lib/features/address_validator/money_badger_validator.dart
@@ -31,6 +31,7 @@ class MoneyBadgerValidator {
   static final _retailerRegexes = {
     'PnP': RegExp(r'(.*)(za\.co\.electrum\.picknpay)(.*)'),
     'Ecentric': RegExp(r'(.*)(za\.co\.ecentric)(.*)'),
+    'Bootleggers': RegExp(r'((.*)(wigroup\.co|yoyogroup\.co)(.*))'),
   };
 
   /// Validates if a QR code is from a supported MoneyBadger retailer

--- a/test/money_badger_validator_test.dart
+++ b/test/money_badger_validator_test.dart
@@ -45,6 +45,16 @@ void main() {
       expect(lightningAddress, contains('za.co.electrum.picknpay'));
     });
 
+    test('converts Bootlegger QR to Lightning address on testnet', () {
+      const qrData ='https://za.wigroup.co/bill/415267598';
+
+      final lightningAddress = MoneyBadgerValidator.convertToLightningAddress(
+          qrData,
+          isTestnet: true);
+      expect(lightningAddress, contains('@staging.cryptoqr.net'));
+      expect(lightningAddress, contains('https%3A%2F%2Fza.wigroup.co%2Fbill%2F415267598'));
+    });
+
     test('properly encodes special characters', () {
       const qrData =
           '00020129530023za.co.electrum.picknpay0122TZHN7RSZPFAR3K/confirm+520458125303710540115802ZA5916cryptoqrtestscan6002CT63049FB8';


### PR DESCRIPTION
Moneybadger has added Bootleggers Coffee to our merchant network, and we are sponsoring Bitcoin meetups there across the country. https://www.moneybadger.co.za/meetups

Naturally, the big thing we get asked for is when Aqua will work there without using our companion app :)