### PR TITLE
Surface balances for non-curated Liquid assets

### DIFF
--- a/lib/config/constants/pref_keys.dart
+++ b/lib/config/constants/pref_keys.dart
@@ -14,6 +14,9 @@ class PrefKeys {
   static const userAssets = 'user_assets';
   static const userRegtestAssets = 'user_regtest_assets';
   static const userTestnetAssets = 'user_testnet_assets';
+  static const discoveredAssets = 'discovered_assets';
+  static const discoveredTestnetAssets = 'discovered_testnet_assets';
+  static const discoveredRegtestAssets = 'discovered_regtest_assets';
   static const hiddenLanguages = 'hidden_languages';
   static const enabledConversionCurrencies = 'enabled_conversion_currencies';
   static const directPegIn = 'direct_peg_in';

--- a/lib/data/provider/network_frontend.dart
+++ b/lib/data/provider/network_frontend.dart
@@ -453,8 +453,10 @@ abstract class NetworkFrontend {
 
   Future<Map<String, GdkAssetInformation>?> getAssets() async {
     final userAssetIds = ref.read(prefsProvider).userAssetIds;
+    final balanceKeys = _allBalances?.keys.cast<String>().toList() ?? [];
+    final allIds = {...userAssetIds, ...balanceKeys}.toList();
     GdkGetAssetsParameters params =
-        GdkGetAssetsParameters(assetsId: userAssetIds);
+        GdkGetAssetsParameters(assetsId: allIds);
 
     final result = await session.getAssets(params: params);
     if (result.asValue != null && result.asValue?.value != null) {

--- a/lib/features/settings/manage_assets/pages/manage_assets_screen.dart
+++ b/lib/features/settings/manage_assets/pages/manage_assets_screen.dart
@@ -15,6 +15,10 @@ class ManageAssetsScreen extends HookConsumerWidget {
     final assets = ref.watch(manageAssetsProvider.select((p) => p.allAssets));
     final userAssets =
         ref.watch(manageAssetsProvider.select((p) => p.userAssets));
+    final discovered =
+        ref.watch(manageAssetsProvider.select((p) => p.discoveredAssets));
+    final enabledDiscovered =
+        ref.watch(manageAssetsProvider.select((p) => p.enabledDiscoveredAssets));
     final items = useMemoized(() => assets, [assets.length]);
 
     return DesignRevampScaffold(
@@ -23,85 +27,140 @@ class ManageAssetsScreen extends HookConsumerWidget {
         title: context.loc.manageAssets,
         colors: context.aquaColors,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(8),
-          child: assets.isNotEmpty
-              ? SeparatedReorderableListView.separated(
-                  itemCount: items.length,
-                  physics: const BouncingScrollPhysics(),
-                  shrinkWrap: true,
-                  handleOnlyMode: true,
-                  onReorder: (oldIndex, newIndex) {
-                    final item = items.removeAt(oldIndex);
-                    items.insert(newIndex, item);
+      body: SingleChildScrollView(
+        physics: const BouncingScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: assets.isNotEmpty
+                    ? SeparatedReorderableListView.separated(
+                        itemCount: items.length,
+                        physics: const NeverScrollableScrollPhysics(),
+                        shrinkWrap: true,
+                        handleOnlyMode: true,
+                        onReorder: (oldIndex, newIndex) {
+                          final item = items.removeAt(oldIndex);
+                          items.insert(newIndex, item);
 
-                    // Only save the order of enabled assets
-                    final enabledAssets = items
-                        .where((asset) => userAssets.contains(asset))
-                        .toList();
-                    Future.microtask(
-                      () async => ref.read(manageAssetsProvider).saveAssets(
-                            enabledAssets,
-                          ),
-                    );
-                  },
-                  proxyDecorator: (child, index, _) => Card(
-                    elevation: 8.0,
-                    child: child,
-                  ),
-                  separatorBuilder: (_, __) => const SizedBox(height: 1),
-                  itemBuilder: (_, index) {
-                    final asset = items[index];
-                    return AquaListItem(
-                      key: ValueKey(asset),
-                      title:
-                          asset.isLBTC ? context.loc.layer2Bitcoin : asset.name,
-                      iconLeading: asset.isLBTC
-                          ? AquaAssetIcon.l2Bitcoin(
-                              size: 40,
-                            )
-                          : AquaAssetIcon.fromUrl(
-                              url: asset.logoUrl,
-                              size: 40,
+                          // Only save the order of enabled assets
+                          final enabledAssets = items
+                              .where((asset) => userAssets.contains(asset))
+                              .toList();
+                          Future.microtask(
+                            () async =>
+                                ref.read(manageAssetsProvider).saveAssets(
+                                      enabledAssets,
+                                    ),
+                          );
+                        },
+                        proxyDecorator: (child, index, _) => Card(
+                          elevation: 8.0,
+                          child: child,
+                        ),
+                        separatorBuilder: (_, __) => const SizedBox(height: 1),
+                        itemBuilder: (_, index) {
+                          final asset = items[index];
+                          return AquaListItem(
+                            key: ValueKey(asset),
+                            title: asset.isLBTC
+                                ? context.loc.layer2Bitcoin
+                                : asset.name,
+                            iconLeading: asset.isLBTC
+                                ? AquaAssetIcon.l2Bitcoin(
+                                    size: 40,
+                                  )
+                                : AquaAssetIcon.fromUrl(
+                                    url: asset.logoUrl,
+                                    size: 40,
+                                  ),
+                            iconTrailing: Row(
+                              children: [
+                                if (asset.isRemovable)
+                                  AquaToggle(
+                                    value: userAssets.contains(asset),
+                                    onChanged: (value) {
+                                      Future.microtask(
+                                        () {
+                                          if (userAssets.contains(asset)) {
+                                            ref
+                                                .read(manageAssetsProvider)
+                                                .removeAsset(asset);
+                                          } else {
+                                            ref
+                                                .read(manageAssetsProvider)
+                                                .addAsset(asset);
+                                          }
+                                        },
+                                      );
+                                    },
+                                  ),
+                                const SizedBox(width: 16),
+                                SeparatedReorderableListView.buildDragHandle(
+                                  index: index,
+                                  child: AquaIcon.grab(
+                                    size: 18,
+                                  ),
+                                ),
+                              ],
                             ),
-                      iconTrailing: Row(
-                        children: [
-                          if (asset.isRemovable)
-                            AquaToggle(
-                              value: userAssets.contains(asset),
-                              onChanged: (value) {
-                                Future.microtask(
-                                  () {
-                                    if (userAssets.contains(asset)) {
-                                      ref
-                                          .read(manageAssetsProvider)
-                                          .removeAsset(asset);
-                                    } else {
-                                      ref
-                                          .read(manageAssetsProvider)
-                                          .addAsset(asset);
-                                    }
-                                  },
-                                );
-                              },
-                            ),
-                          const SizedBox(width: 16),
-                          SeparatedReorderableListView.buildDragHandle(
-                            index: index,
-                            child: AquaIcon.grab(
-                              size: 18,
-                            ),
-                          ),
-                        ],
+                          );
+                        },
+                      )
+                    : AssetListErrorView(
+                        message: context.loc.manageAssetsScreenError,
                       ),
-                    );
-                  },
-                )
-              : AssetListErrorView(
-                  message: context.loc.manageAssetsScreenError,
+              ),
+              if (discovered.isNotEmpty) ...[
+                const SizedBox(height: 24),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    context.loc.manageAssetsOtherAssets,
+                    style: context.textTheme.titleMedium,
+                  ),
                 ),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Column(
+                    children: discovered.map((asset) {
+                      final isEnabled = enabledDiscovered.contains(asset);
+                      return AquaListItem(
+                        key: ValueKey('discovered_${asset.id}'),
+                        title: asset.name,
+                        subtitle: asset.ticker,
+                        iconLeading: AquaAssetIcon.fromUrl(
+                          url: asset.logoUrl,
+                          size: 40,
+                        ),
+                        iconTrailing: AquaToggle(
+                          value: isEnabled,
+                          onChanged: (value) {
+                            Future.microtask(
+                              () {
+                                if (isEnabled) {
+                                  ref
+                                      .read(manageAssetsProvider)
+                                      .removeDiscoveredAsset(asset);
+                                } else {
+                                  ref
+                                      .read(manageAssetsProvider)
+                                      .addDiscoveredAsset(asset);
+                                }
+                              },
+                            );
+                          },
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/settings/manage_assets/providers/manage_assets_provider.dart
+++ b/lib/features/settings/manage_assets/providers/manage_assets_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:aqua/config/constants/svgs.dart';
 import 'package:aqua/data/provider/liquid_provider.dart';
 import 'package:aqua/features/marketplace/api_services/marketplace_service.dart';
 import 'package:aqua/features/settings/settings.dart';
@@ -107,20 +108,62 @@ final availableAssetsProvider =
   return allAssets;
 });
 
+final discoveredAssetsProvider =
+    FutureProvider.autoDispose<List<Asset>>((ref) async {
+  final balances =
+      await ref.read(liquidProvider).getBalance(requiresRefresh: false) ?? {};
+  final curatedIds = ref
+          .watch(availableAssetsProvider)
+          .asData
+          ?.value
+          ?.map((a) => a.id)
+          .toSet() ??
+      {};
+  final policyAsset = ref.read(liquidProvider).policyAsset;
+
+  // Asset IDs with balance that are NOT in the curated list
+  final unknownIds = balances.keys
+      .where((id) => !curatedIds.contains(id))
+      .where((id) => id != policyAsset)
+      .where((id) => (balances[id] as int? ?? 0) > 0)
+      .toList();
+
+  if (unknownIds.isEmpty) return [];
+
+  // Fetch metadata from GDK asset registry (local cache)
+  final rawAssets = ref.read(liquidProvider).allRawAssets ?? {};
+
+  return unknownIds.map((id) {
+    final info = rawAssets[id];
+    return Asset(
+      id: id,
+      name: info?.name ?? id.substring(0, 8),
+      ticker: info?.ticker ?? '???',
+      logoUrl: Svgs.unknownAsset,
+      precision: info?.precision ?? 8,
+      isLiquid: true,
+      isRemovable: true,
+      amount: balances[id] as int? ?? 0,
+    );
+  }).toList();
+});
+
 final manageAssetsProvider = Provider.autoDispose<ManageAssetsProvider>((ref) {
   final env = ref.watch(envProvider);
   final prefs = ref.watch(prefsProvider);
   final assets = ref.watch(availableAssetsProvider).asData?.value ?? [];
-  return ManageAssetsProvider(env, prefs, assets);
+  final discovered = ref.watch(discoveredAssetsProvider).asData?.value ?? [];
+  return ManageAssetsProvider(env, prefs, assets, discovered);
 });
 
 class ManageAssetsProvider extends ChangeNotifier {
-  ManageAssetsProvider(this.env, this.prefs, this.allAssets);
+  ManageAssetsProvider(this.env, this.prefs, this.allAssets, this.discoveredAssets);
 
   final Env env;
   final UserPreferencesNotifier prefs;
   //NOTE - The assets supported by Aqua at a given moment (fetched from API)
   final List<Asset> allAssets;
+  final List<Asset> discoveredAssets;
 
   //NOTE - These are all the assets that are currently enabled by the user.
   //This is supposed to be a subset of [availableAssets].
@@ -153,6 +196,23 @@ class ManageAssetsProvider extends ChangeNotifier {
 
   Future<void> removeAsset(Asset asset) async {
     prefs.removeAsset(asset.id);
+    notifyListeners();
+  }
+
+  List<Asset> get enabledDiscoveredAssets {
+    return prefs.discoveredAssetIds
+        .map((id) => discoveredAssets.firstWhereOrNull((a) => a.id == id))
+        .whereType<Asset>()
+        .toList();
+  }
+
+  Future<void> addDiscoveredAsset(Asset asset) async {
+    prefs.addDiscoveredAsset(asset.id);
+    notifyListeners();
+  }
+
+  Future<void> removeDiscoveredAsset(Asset asset) async {
+    prefs.removeDiscoveredAsset(asset.id);
     notifyListeners();
   }
 

--- a/lib/features/settings/shared/providers/prefs_provider.dart
+++ b/lib/features/settings/shared/providers/prefs_provider.dart
@@ -306,6 +306,37 @@ class UserPreferencesNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
+  //ANCHOR Discovered Assets
+  String get _discoveredAssetsKey {
+    switch (_env) {
+      case Env.mainnet:
+        return PrefKeys.discoveredAssets;
+      case Env.testnet:
+        return PrefKeys.discoveredTestnetAssets;
+      case Env.regtest:
+        return PrefKeys.discoveredRegtestAssets;
+      default:
+        return PrefKeys.discoveredAssets;
+    }
+  }
+
+  List<String> get discoveredAssetIds =>
+      _prefs.getStringList(_discoveredAssetsKey) ?? [];
+
+  Future<void> addDiscoveredAsset(String assetId) async {
+    if (!discoveredAssetIds.contains(assetId)) {
+      final updated = [...discoveredAssetIds, assetId];
+      await _prefs.setStringList(_discoveredAssetsKey, updated);
+      notifyListeners();
+    }
+  }
+
+  Future<void> removeDiscoveredAsset(String assetId) async {
+    final updated = discoveredAssetIds.where((id) => id != assetId).toList();
+    await _prefs.setStringList(_discoveredAssetsKey, updated);
+    notifyListeners();
+  }
+
   //ANCHOR - Direct Peg In
 
   bool get isDirectPegInEnabled =>

--- a/lib/features/shared/providers/assets_provider.dart
+++ b/lib/features/shared/providers/assets_provider.dart
@@ -67,12 +67,17 @@ class AssetsNotifier extends AsyncNotifier<List<Asset>> {
                 {};
         logger.debug('[AssetsProvider] Liquid balances: $balances');
 
-        final assets = ref
+        final userAssets = ref
             .read(manageAssetsProvider.select((p) => p.userAssets))
             .map((asset) => balances.containsKey(asset.id)
                 ? asset.copyWith(amount: balances[asset.id] as int)
                 : asset);
-        return [btcAsset, ...assets];
+        final discovered = ref
+            .read(manageAssetsProvider.select((p) => p.enabledDiscoveredAssets))
+            .map((asset) => balances.containsKey(asset.id)
+                ? asset.copyWith(amount: balances[asset.id] as int)
+                : asset);
+        return [btcAsset, ...userAssets, ...discovered];
       }).distinct((previous, current) =>
           // Only let the event pass if:
           // - the list of assets is the same length

--- a/lib/gdk.dart
+++ b/lib/gdk.dart
@@ -1083,6 +1083,13 @@ class LibGdk {
       outputMap[key] = GdkAssetInformation.fromJson(asset);
     }
 
+    final iconsMap = jsonMap['icons'] as Map<String, dynamic>;
+    for (var key in outputMap.keys) {
+      if (iconsMap.containsKey(key)) {
+        outputMap[key] = outputMap[key]!.copyWith(icon: iconsMap[key] as String?);
+      }
+    }
+
     return Result.value(outputMap);
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -251,6 +251,7 @@
   "loginScreenTitle": "Sign Up / Log In",
   "low": "Low Priority",
   "manageAssets": "Manage Assets",
+  "manageAssetsOtherAssets": "Other Assets",
   "manageAssetsScreenError": "Failed to load assets list. Please try again later.",
   "marketplaceScreenBtcMapButton": "BTC Map",
   "marketplaceScreenBtcMapButtonDescription": "Find merchants that accept Bitcoin\n",

--- a/test/manage_assets_provider_test.dart
+++ b/test/manage_assets_provider_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:aqua/config/constants/svgs.dart';
 import 'package:aqua/data/data.dart';
 import 'package:aqua/features/marketplace/api_services/marketplace_service.dart';
 import 'package:aqua/features/settings/settings.dart';
@@ -283,4 +284,385 @@ void main() {
       verifyNever(() => mockMarketplaceService.fetchAssets());
     });
   });
+
+  group('ManageAssetsProvider', () {
+    late MockUserPreferencesNotifier mockPrefs;
+
+    const kEurxId =
+        '18729918ab4bca843656f08d4dd877bed6641fbd596a0a963abbf199cfeb3cec';
+    const kMexId =
+        '26ac924263ba547b706251635550a8649545ee5c074fe5db8d7140557baaf32e';
+    const kUnknownId =
+        '8a4053ef1b2f3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d';
+
+    final curatedAssets = [
+      Asset(
+        id: kLbtcId,
+        name: 'Liquid Bitcoin',
+        ticker: 'L-BTC',
+        logoUrl:
+            'https://aqua-asset-logos.s3.us-west-2.amazonaws.com/L-BTC.svg',
+        isDefaultAsset: true,
+        isRemovable: false,
+        isLiquid: true,
+        isLBTC: true,
+      ),
+      Asset(
+        id: kUsdtId,
+        name: 'Tether USDt',
+        ticker: 'USDt',
+        logoUrl:
+            'https://aqua-asset-logos.s3.us-west-2.amazonaws.com/USDt.svg',
+        isDefaultAsset: true,
+        isRemovable: true,
+        isLiquid: true,
+        isUSDt: true,
+      ),
+      Asset(
+        id: kEurxId,
+        name: 'PEGx EURx',
+        ticker: 'EURx',
+        logoUrl:
+            'https://aqua-asset-logos.s3.us-west-2.amazonaws.com/EURx.svg',
+        isRemovable: true,
+        isLiquid: true,
+      ),
+    ];
+
+    final discoveredAssetsList = [
+      Asset(
+        id: kUnknownId,
+        name: 'SomeToken',
+        ticker: 'STK',
+        logoUrl: Svgs.unknownAsset,
+        precision: 8,
+        isLiquid: true,
+        isRemovable: true,
+        amount: 100000,
+      ),
+    ];
+
+    setUp(() {
+      mockPrefs = MockUserPreferencesNotifier();
+    });
+
+    test('userAssets returns assets matching user pref IDs', () {
+      when(() => mockPrefs.userAssetIds)
+          .thenReturn([kLbtcId, kUsdtId, kEurxId]);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        [],
+      );
+
+      expect(provider.userAssets.length, 3);
+      expect(provider.userAssets.first.id, kLbtcId);
+    });
+
+    test('availableAssets excludes already enabled assets', () {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId, kUsdtId]);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        [],
+      );
+
+      // EURx is removable and not in userAssetIds, so it should be available
+      expect(provider.availableAssets.length, 1);
+      expect(provider.availableAssets.first.id, kEurxId);
+    });
+
+    test('enabledDiscoveredAssets returns empty when no discovered prefs', () {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+      when(() => mockPrefs.discoveredAssetIds).thenReturn([]);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        discoveredAssetsList,
+      );
+
+      expect(provider.enabledDiscoveredAssets, isEmpty);
+    });
+
+    test('enabledDiscoveredAssets returns matching discovered assets', () {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+      when(() => mockPrefs.discoveredAssetIds).thenReturn([kUnknownId]);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        discoveredAssetsList,
+      );
+
+      expect(provider.enabledDiscoveredAssets.length, 1);
+      expect(provider.enabledDiscoveredAssets.first.id, kUnknownId);
+      expect(provider.enabledDiscoveredAssets.first.ticker, 'STK');
+    });
+
+    test('enabledDiscoveredAssets ignores IDs not in discovered list', () {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+      when(() => mockPrefs.discoveredAssetIds)
+          .thenReturn(['nonexistent_asset_id']);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        discoveredAssetsList,
+      );
+
+      expect(provider.enabledDiscoveredAssets, isEmpty);
+    });
+
+    test('addDiscoveredAsset delegates to prefs', () async {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+      when(() => mockPrefs.discoveredAssetIds).thenReturn([]);
+      when(() => mockPrefs.addDiscoveredAsset(any()))
+          .thenAnswer((_) async {});
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        discoveredAssetsList,
+      );
+
+      await provider.addDiscoveredAsset(discoveredAssetsList.first);
+
+      verify(() => mockPrefs.addDiscoveredAsset(kUnknownId)).called(1);
+    });
+
+    test('removeDiscoveredAsset delegates to prefs', () async {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+      when(() => mockPrefs.discoveredAssetIds).thenReturn([kUnknownId]);
+      when(() => mockPrefs.removeDiscoveredAsset(any()))
+          .thenAnswer((_) async {});
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        discoveredAssetsList,
+      );
+
+      await provider.removeDiscoveredAsset(discoveredAssetsList.first);
+
+      verify(() => mockPrefs.removeDiscoveredAsset(kUnknownId)).called(1);
+    });
+
+    test('discoveredAssets field is accessible', () {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        discoveredAssetsList,
+      );
+
+      expect(provider.discoveredAssets.length, 1);
+      expect(provider.discoveredAssets.first.id, kUnknownId);
+    });
+
+    test('discoveredAssets empty when no non-curated assets exist', () {
+      when(() => mockPrefs.userAssetIds).thenReturn([kLbtcId]);
+
+      final provider = ManageAssetsProvider(
+        Env.mainnet,
+        mockPrefs,
+        curatedAssets,
+        [],
+      );
+
+      expect(provider.discoveredAssets, isEmpty);
+    });
+  });
+
+  group('discoveredAssetsProvider', () {
+    const kUnknownAssetId =
+        '8a4053ef1b2f3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d';
+
+    test('returns empty list when all balances are curated', () async {
+      final mockLiquidProvider = MockLiquidProvider();
+      final mockSharedPreferences = MockSharedPreferences();
+
+      when(() => mockLiquidProvider.policyAsset).thenReturn(kLbtcId);
+      when(() => mockLiquidProvider.usdtId).thenReturn(kUsdtId);
+      when(() => mockLiquidProvider.getBalance(requiresRefresh: false))
+          .thenAnswer((_) async => {
+                kLbtcId: 50000,
+                kUsdtId: 100000,
+              });
+      when(() => mockSharedPreferences.setStringList(any(), any()))
+          .thenAnswer((_) async => true);
+
+      when(() => mockMarketplaceService.fetchAssets()).thenAnswer(
+        (_) async => Response(
+          http.Response(jsonEncode(assetsJson), 200),
+          AssetsResponse.fromJson(assetsJson),
+        ),
+      );
+
+      final testContainer = ProviderContainer(overrides: [
+        marketplaceServiceProvider.overrideWithValue(mockMarketplaceService),
+        sharedPreferencesProvider.overrideWithValue(mockSharedPreferences),
+        liquidProvider.overrideWithValue(mockLiquidProvider),
+        envProvider
+            .overrideWith((ref) => FakeEnvNotifier(mockSharedPreferences)),
+      ]);
+
+      addTearDown(testContainer.dispose);
+
+      // First resolve availableAssetsProvider so discoveredAssetsProvider can use it
+      await testContainer.read(availableAssetsProvider.future);
+      final result =
+          await testContainer.read(discoveredAssetsProvider.future);
+
+      expect(result, isEmpty);
+    });
+
+    test('returns discovered assets for non-curated balances', () async {
+      final mockLiquidProvider = MockLiquidProvider();
+      final mockSharedPreferences = MockSharedPreferences();
+
+      when(() => mockLiquidProvider.policyAsset).thenReturn(kLbtcId);
+      when(() => mockLiquidProvider.usdtId).thenReturn(kUsdtId);
+      when(() => mockLiquidProvider.getBalance(requiresRefresh: false))
+          .thenAnswer((_) async => {
+                kLbtcId: 50000,
+                kUsdtId: 100000,
+                kUnknownAssetId: 75000,
+              });
+      when(() => mockLiquidProvider.allRawAssets).thenReturn({
+        kUnknownAssetId: const GdkAssetInformation(
+          name: 'Some Token',
+          ticker: 'STK',
+          precision: 8,
+        ),
+      });
+      when(() => mockSharedPreferences.setStringList(any(), any()))
+          .thenAnswer((_) async => true);
+
+      when(() => mockMarketplaceService.fetchAssets()).thenAnswer(
+        (_) async => Response(
+          http.Response(jsonEncode(assetsJson), 200),
+          AssetsResponse.fromJson(assetsJson),
+        ),
+      );
+
+      final testContainer = ProviderContainer(overrides: [
+        marketplaceServiceProvider.overrideWithValue(mockMarketplaceService),
+        sharedPreferencesProvider.overrideWithValue(mockSharedPreferences),
+        liquidProvider.overrideWithValue(mockLiquidProvider),
+        envProvider
+            .overrideWith((ref) => FakeEnvNotifier(mockSharedPreferences)),
+      ]);
+
+      addTearDown(testContainer.dispose);
+
+      await testContainer.read(availableAssetsProvider.future);
+      final result =
+          await testContainer.read(discoveredAssetsProvider.future);
+
+      expect(result.length, 1);
+      expect(result.first.id, kUnknownAssetId);
+      expect(result.first.name, 'Some Token');
+      expect(result.first.ticker, 'STK');
+      expect(result.first.logoUrl, Svgs.unknownAsset);
+      expect(result.first.isLiquid, true);
+      expect(result.first.isRemovable, true);
+      expect(result.first.amount, 75000);
+    });
+
+    test('excludes policy asset from discovered assets', () async {
+      final mockLiquidProvider = MockLiquidProvider();
+      final mockSharedPreferences = MockSharedPreferences();
+
+      when(() => mockLiquidProvider.policyAsset).thenReturn(kLbtcId);
+      when(() => mockLiquidProvider.usdtId).thenReturn(kUsdtId);
+      // Balance only has policy asset (which is already curated anyway)
+      // and an unknown asset with zero balance
+      when(() => mockLiquidProvider.getBalance(requiresRefresh: false))
+          .thenAnswer((_) async => {
+                kLbtcId: 50000,
+                kUnknownAssetId: 0,
+              });
+      when(() => mockSharedPreferences.setStringList(any(), any()))
+          .thenAnswer((_) async => true);
+
+      when(() => mockMarketplaceService.fetchAssets()).thenAnswer(
+        (_) async => Response(
+          http.Response(jsonEncode(assetsJson), 200),
+          AssetsResponse.fromJson(assetsJson),
+        ),
+      );
+
+      final testContainer = ProviderContainer(overrides: [
+        marketplaceServiceProvider.overrideWithValue(mockMarketplaceService),
+        sharedPreferencesProvider.overrideWithValue(mockSharedPreferences),
+        liquidProvider.overrideWithValue(mockLiquidProvider),
+        envProvider
+            .overrideWith((ref) => FakeEnvNotifier(mockSharedPreferences)),
+      ]);
+
+      addTearDown(testContainer.dispose);
+
+      await testContainer.read(availableAssetsProvider.future);
+      final result =
+          await testContainer.read(discoveredAssetsProvider.future);
+
+      expect(result, isEmpty);
+    });
+
+    test('uses truncated ID as name when GDK has no metadata', () async {
+      final mockLiquidProvider = MockLiquidProvider();
+      final mockSharedPreferences = MockSharedPreferences();
+
+      when(() => mockLiquidProvider.policyAsset).thenReturn(kLbtcId);
+      when(() => mockLiquidProvider.usdtId).thenReturn(kUsdtId);
+      when(() => mockLiquidProvider.getBalance(requiresRefresh: false))
+          .thenAnswer((_) async => {
+                kUnknownAssetId: 50000,
+              });
+      when(() => mockLiquidProvider.allRawAssets).thenReturn({});
+      when(() => mockSharedPreferences.setStringList(any(), any()))
+          .thenAnswer((_) async => true);
+
+      when(() => mockMarketplaceService.fetchAssets()).thenAnswer(
+        (_) async => Response(
+          http.Response(jsonEncode(assetsJson), 200),
+          AssetsResponse.fromJson(assetsJson),
+        ),
+      );
+
+      final testContainer = ProviderContainer(overrides: [
+        marketplaceServiceProvider.overrideWithValue(mockMarketplaceService),
+        sharedPreferencesProvider.overrideWithValue(mockSharedPreferences),
+        liquidProvider.overrideWithValue(mockLiquidProvider),
+        envProvider
+            .overrideWith((ref) => FakeEnvNotifier(mockSharedPreferences)),
+      ]);
+
+      addTearDown(testContainer.dispose);
+
+      await testContainer.read(availableAssetsProvider.future);
+      final result =
+          await testContainer.read(discoveredAssetsProvider.future);
+
+      expect(result.length, 1);
+      expect(result.first.name, kUnknownAssetId.substring(0, 8));
+      expect(result.first.ticker, '???');
+      expect(result.first.precision, 8);
+    });
+  });
 }
+
+class MockUserPreferencesNotifier extends Mock
+    implements UserPreferencesNotifier {}

--- a/test/mocks/manage_assets_provider_mocks.dart
+++ b/test/mocks/manage_assets_provider_mocks.dart
@@ -16,4 +16,12 @@ extension MockManageAssetsProviderX on MockManageAssetsProvider {
   void mockLiquidUsdtAssetCall({required Asset asset}) {
     when(() => liquidUsdtAsset).thenReturn(asset);
   }
+
+  void mockDiscoveredAssets({required List<Asset> assets}) {
+    when(() => discoveredAssets).thenReturn(assets);
+  }
+
+  void mockEnabledDiscoveredAssets({required List<Asset> assets}) {
+    when(() => enabledDiscoveredAssets).thenReturn(assets);
+  }
 }


### PR DESCRIPTION
Closes #103

## Summary

Users who receive Liquid tokens not in the curated list (~5 tokens) cannot see their balances. GDK's `getBalance()` returns all balances, but `assets_provider.dart` silently discards any balance not matching a curated asset ID. This is a fund visibility issue.

This PR:
- Populates the existing `GdkAssetInformation.icon` field from GDK's icon registry data (previously discarded)
- Expands `getAssets()` to include balance keys so GDK returns metadata for discovered assets
- Adds a `discoveredAssetsProvider` that detects non-curated assets with positive balance and fetches their metadata from GDK's local registry
- Adds an "Other Assets" section to the Manage Assets screen with toggle on/off support
- Includes discovered assets in the home screen balance stream when enabled

## Design decisions

- Discovered assets default to **off** (opt-in visibility)
- Curated asset behavior is **completely unchanged**
- No new models, screens, routes, or dependencies
- Uses existing `AquaListItem` + `AquaToggle` patterns
- Assets with no GDK metadata show truncated ID as name and "???" as ticker

## Files changed (8 source + 2 test)

| File | Change |
|------|--------|
| `gdk.dart` | Populate icon from GDK icons map |
| `network_frontend.dart` | Include balance keys in `getAssets()` |
| `pref_keys.dart` | Add discovered asset pref keys |
| `prefs_provider.dart` | Add discovered asset preferences |
| `manage_assets_provider.dart` | Add `discoveredAssetsProvider` + expand `ManageAssetsProvider` |
| `assets_provider.dart` | Include enabled discovered assets in balance stream |
| `manage_assets_screen.dart` | Add "Other Assets" UI section |
| `app_en.arb` | Add localization key |
| `manage_assets_provider_test.dart` | Unit tests for new provider logic |
| `manage_assets_provider_mocks.dart` | Add mock helpers for discovered assets |

## Testing

- Added 11 unit tests covering `ManageAssetsProvider` and `discoveredAssetsProvider`
- Tests cover: empty discovered list, non-curated balance detection, policy asset exclusion, zero-balance filtering, missing GDK metadata fallback, add/remove delegation
- Full integration testing requires the team's build environment due to the `private_integrations` dependency ([FAQ](https://jan3.zendesk.com/hc/en-us/articles/41061834870811-I-Can-t-Build-AQUA-from-Source))